### PR TITLE
Strip trailing dot for new domain record

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func (s *linodeSolver) Present(ch *acme.ChallengeRequest) error {
 
 	_, err = c.CreateDomainRecord(context.Background(), domain.ID, linodego.DomainRecordCreateOptions{
 		Type: linodego.RecordTypeTXT,
-		Name: ch.ResolvedFQDN,
+		Name: strings.TrimRight(ch.ResolvedFQDN, "."),
 
 		Target: ch.Key,
 		Weight: &weight,


### PR DESCRIPTION
Fixes issue #1 (Error: [400] [name] Name contains invalid characters).

I have tested this on my own setup:
1. Created and pushed new docker image with my changes.
2. Replaced docker image with my own for the cert-manager-linode deployment on my cluster.
3. Issued a new certificate with no problems, watched as the _acme-challenge record was succesfully created.

